### PR TITLE
Improve script

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-set -e
-set -o pipefail
+set -euo pipefail
+
 main() {
   echo "Current ref: ${GITHUB_REF}"
   BRANCH=${GITHUB_REF:11}
@@ -13,15 +13,15 @@ main() {
 
   # Using git directly because the $GITHUB_EVENT_PATH file only shows commits in
   # most recent push.
-  /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin master
-  /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --shallow-exclude=master origin ${BRANCH}
+  /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin master --quiet
+  /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --shallow-exclude=master origin ${BRANCH} --quiet
 
   # Get the list before the "|| true" to fail the script when the git cmd fails.
   FIXUP_LIST=`/usr/bin/git log --pretty=format:%s origin/master..origin/${BRANCH}`
-  FIXUP_COUNT=`echo $FIXUP_LIST | grep fixup! | wc -l || true`
+  FIXUP_COUNT=`echo $FIXUP_LIST | grep -c '^fixup!' || true`
   echo "Fixup! commits: ${FIXUP_COUNT}"
   if [ "$FIXUP_COUNT" -gt "0" ]; then
-    /usr/bin/git log --pretty=format:%s origin/master..origin/${BRANCH} | grep fixup!
+    /usr/bin/git log --pretty=format:%s origin/master..origin/${BRANCH} | grep '^fixup!'
     echo "failing..."
     exit 1
   fi


### PR DESCRIPTION
1. remove `--progress` and add `--quiet` to git fetch commands to make the log
   usable
2. use `set -euo pipefail` which will also fail if variables that are not set
   are accessed
3. remove `wc -l` from pipeline, it is unreliable, also if someone uses
   '**fixup!**' in the commit message (which shouldn't but can happen), it will
   now only count if it is the first expression of the line.